### PR TITLE
Reuse shared video annotator instance in worker thread

### DIFF
--- a/GUI/main.py
+++ b/GUI/main.py
@@ -26,7 +26,7 @@ class VideoProcessingThread(QThread):
 
     def __init__(self, avt, video_path, output_dir,clicked_x, clicked_y, method,text,save_path):
         super().__init__()
-        self.AVT = AnythingVideo_TW()
+        self.AVT = avt or AnythingVideo_TW()
         self.video_path = video_path
         self.output_dir = output_dir
         self.clicked_x = clicked_x


### PR DESCRIPTION
## Summary
- reuse the AnythingVideo_TW instance provided to VideoProcessingThread so that the shared inference object is not recreated

## Testing
- python - <<'PY'


------
https://chatgpt.com/codex/tasks/task_e_68d9641de128832991df9eeef3d52721